### PR TITLE
Allow bot shutdown without waiting for new message

### DIFF
--- a/iris/bot/__init__.py
+++ b/iris/bot/__init__.py
@@ -87,7 +87,11 @@ class Bot:
                     print("웹소켓에 연결되었습니다")
                     self.bot_id = self.api.get_info()["bot_id"]
                     while True:
-                        recv = ws.recv()
+                        try:
+                            recv = ws.recv(timeout=1)
+                        except TimeoutError:
+                            continue
+
                         try:
                             data: dict = json.loads(recv)
                             data["raw"] = data.get("json")


### PR DESCRIPTION
## Summary
- poll Iris websocket connection with a timeout so KeyboardInterrupt can be processed without waiting for a new message

## Testing
- python -m compileall iris

------
https://chatgpt.com/codex/tasks/task_e_68ca989bd72883229bf208a89733d772